### PR TITLE
让helper直接从ActionController::Base产生

### DIFF
--- a/lib/bootstrap_helper/breadcrumb.rb
+++ b/lib/bootstrap_helper/breadcrumb.rb
@@ -53,10 +53,10 @@ module BootstrapHelper
           if i == (@breadcrumbs.length - 1)
             breadcrumb_content = c
           else
-            breadcrumb_content = c + content_tag(:span, "/", :class => "divider")
+            breadcrumb_content = c + " " + content_tag(:span, "/", :class => "divider")
           end
 
-          crumb += content_tag(:li, breadcrumb_content ,:class => breadcrumb_class )
+          crumb += content_tag(:li, breadcrumb_content ,:class => breadcrumb_class ) + "\n"
         end
         return prefix + content_tag(:ul, crumb, :class => "breadcrumb menu clearfix")
       end

--- a/lib/bootstrap_helper/engine.rb
+++ b/lib/bootstrap_helper/engine.rb
@@ -10,7 +10,7 @@ module BootstrapHelper
       end
 
       config.to_prepare do
-        ApplicationController.send :include, BootstrapHelper::Breadcrumb
+        ActionController::Base.send :include, BootstrapHelper::Breadcrumb
       end
 
     end


### PR DESCRIPTION
使用一些第三方gem的时候，不是从 ApplicationController 继承，如果自定义 layout，有可能会出现无法识别 render_breadcrumb helper 函数的情况，通过在 ActionController::Base 则可解决这个情况。
