### PR TITLE
修改 simple_form 要求的版本

### DIFF
--- a/bootstrap_helper.gemspec
+++ b/bootstrap_helper.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "railties", "~> 3.0"
   gem.add_dependency "thor",     "~> 0.14"
-  gem.add_dependency "simple_form", "~> 2.0.2"
+  gem.add_dependency "simple_form", "~> 2.0"
   gem.add_dependency "will_paginate", '>= 3.0.3'
   gem.add_development_dependency("rspec-rails")
   gem.add_development_dependency("capybara", ">= 0.4.0")


### PR DESCRIPTION
simple_form 升级到 2.1 了，如果在 Gemfile 指定 2.1.0 版的 simple_form 则会与 bootstrap-helper 中使用的 simple_form 的冲突
