### PR TITLE
Update bootstrap_helper.gemspec

### DIFF
--- a/bootstrap_helper.gemspec
+++ b/bootstrap_helper.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = BootstrapHelper::Rails::VERSION
 
-  gem.add_dependency "railties", "4.0.0.rc1"
+  gem.add_dependency "railties", "4.0.0.rc2"
   gem.add_dependency "thor",     "~> 0.14"
   gem.add_dependency "will_paginate", '>= 3.0.3'
   gem.add_development_dependency("rspec-rails")


### PR DESCRIPTION
Didn't test. I am writing an app with rails 4.rc2 and can't use this gem.
