### PR TITLE
Don't insert divider to breadcrumb items

### DIFF
--- a/lib/bootstrap_helper/breadcrumb.rb
+++ b/lib/bootstrap_helper/breadcrumb.rb
@@ -50,11 +50,7 @@ module BootstrapHelper
           breadcrumb_class << "first" if i == 0
           breadcrumb_class << "last active" if i == (@breadcrumbs.length - 1)
 
-          if i == (@breadcrumbs.length - 1)
-            breadcrumb_content = c
-          else
-            breadcrumb_content = c + " " + content_tag(:span, "/", :class => "divider")
-          end
+          breadcrumb_content = c
 
           crumb += content_tag(:li, breadcrumb_content ,:class => breadcrumb_class ) + "\n"
         end


### PR DESCRIPTION
Bootstrap v3 inserts divider automatically so it's unnecessary.
