### PR TITLE
mapping to new color name of Bootstrap 3

### DIFF
--- a/lib/bootstrap_helper/helper.rb
+++ b/lib/bootstrap_helper/helper.rb
@@ -30,7 +30,14 @@ module BootstrapHelper
     def notice_message
       flash_messages = []
       flash.each do |type, message|
-        type = :success if type == :notice
+        case type   # mapping to new color name of Bootstrap 3
+          when :error
+            type = :danger
+          when :alert
+            type = :warning
+          when :notice
+            type = :info
+        end
         text = content_tag(:div, link_to("x", "#", :class => "close", "data-dismiss" => "alert") + message, :class => "alert fade in alert-#{type}")
         flash_messages << text if message
       end


### PR DESCRIPTION
Bootstrap 3 has changed its color name. 

Espeically the following,
alert-error (bootstrap 2.3) => alert-danger (bootstrap 3)
